### PR TITLE
reverted back onSnapshot for homepage and settings 

### DIFF
--- a/src/screens/main/DeleteAccountPage.js
+++ b/src/screens/main/DeleteAccountPage.js
@@ -17,11 +17,8 @@ const DeleteAccountPage= () => {
     const auth = getAuth();
     const user = auth.currentUser;
     const credential = EmailAuthProvider.credential(email, oldPassword);
-    const collectionRef = firestore.collection('users')
-    const userRef = firestore.collection('users').doc(auth.currentUser.uid)
 
     const storage = getStorage();
-    const reference = ref(storage, `profilepics/${auth.currentUser.uid}`);
     //find a way to delete the pic and user data without throwing error because of snapshot
 
 
@@ -30,13 +27,29 @@ const DeleteAccountPage= () => {
     const confirmDeleteData = () => {
         reauthenticateWithCredential(user, credential).then(() => {
             console.log("Successfully reauthenticated")
-            //collectionRef.doc(userRef).delete();
-            console.log("DATA successfully deleted")
+            const imageRef = ref(storage, `profilepics/${auth.currentUser.uid}`);
+
+
+                deleteObject(imageRef).then(() => {
+                    console.log("Got Profile Pic in database, deleting")
+                }).catch((error) => {
+                    console.log("hello no pic if this shows it works")
+                });
+
+
+            deleteDoc(doc(firestore, 'users', auth.currentUser.uid)).then(() => {
+                console.log("DATA successfully deleted")
+
+            }).catch((error) => {
+                alert("hello no data if this shows it works")
+            });
+
             setModalVisible(false)
             setModalVisible2(true)
+
         }).catch((error) => {
             console.log("Unsuccessfully reauthenticated", error)
-            alert("Password or Email is incorrect. Unable to delete account")
+           alert("Password or Email is incorrect. Unable to delete account")
         });
     }
 
@@ -49,14 +62,21 @@ const DeleteAccountPage= () => {
       }
 
     const confirmDeleteAccount = () => {
-        deleteUser(user).then(() => {
-            alert("Account successfully deleted")
-            console.log("Account successfully deleted")
-            navigation.replace("LoginStack")
-        }).catch((error) => {
-            alert(error);
-            console.log(error)})
-        }
+
+
+            deleteUser(user).then(() => {
+                alert("Account successfully deleted")
+                console.log("Account successfully deleted")
+                setModalVisible2(false)
+                navigation.replace("LoginStack")
+
+                
+            }).catch((error) => {
+                alert(error);
+                console.log(error)})
+
+
+}
 
 
     return(

--- a/src/screens/main/HomeScreen.js
+++ b/src/screens/main/HomeScreen.js
@@ -25,11 +25,6 @@ const HomeScreen = (props) => {
             console.log(err)
         })  
 
-        const unsub = onSnapshot(doc(firestore, 'users', auth.currentUser.uid), (doc) => {
-            setName(doc.data()["name"])
-          })
-          return unsub
-
     },[])
  
     const [fees, setFees] = useState(0)

--- a/src/screens/main/LeaderboardScreen.js
+++ b/src/screens/main/LeaderboardScreen.js
@@ -16,21 +16,12 @@ function LeaderboardScreen() {
   const [avgreturns, setAvgreturns] = useState('')
   const userData = useRef(0)
 
+  const storage = getStorage();
+  const reference = ref(storage, `profilepics/${auth.currentUser.uid}`);
+  getDownloadURL(reference).then((x) => {
+  setURL(x);
+  })
 
-   useEffect(() => {
-
-    const collectionRef = collection(firestore, 'users')
-    const q = query(collectionRef, orderBy("highscore", "desc"))
-
-    const unsub = onSnapshot(q, (snapshot) => {
-      setLeaderboardData(snapshot.docs.map((doc) => doc.data()))
-
-    })
-  
-    
-    return unsub
-  }
-  , [])
 
   useEffect(() => {
     const userRef = firestore.collection('users').doc(auth.currentUser.uid)
@@ -40,7 +31,6 @@ function LeaderboardScreen() {
       userData.current=doc.data()['highscore']
     })
     .then(() => {
-
       let x = 1 + leaderboardData.findIndex(x => x['highscore'] === userData.current)
       setRank(x)
     })
@@ -50,11 +40,6 @@ function LeaderboardScreen() {
   }, [leaderboardData])
 
   useEffect(() => {
-    const storage = getStorage();
-    const reference = ref(storage, `profilepics/${auth.currentUser.uid}`);
-    getDownloadURL(reference).then((x) => {
-    setURL(x);
-    })
 
     const collectionRef = collection(firestore, 'users')
     const q = query(collectionRef, orderBy("highscore", "desc"))
@@ -69,12 +54,6 @@ function LeaderboardScreen() {
   , [])
 
 
-  useEffect(() => {
-    const unsub = onSnapshot(doc(firestore, 'users', auth.currentUser.uid), (doc) => {
-      setURL(doc.data()["profpic"])
-    })
-    return unsub
-  })
   
     return (
       <View style={styles.container}>

--- a/src/screens/main/SettingsScreen.js
+++ b/src/screens/main/SettingsScreen.js
@@ -38,16 +38,20 @@ function SettingsScreen() {
           console.log(err)
         })
 
-        const unsub = onSnapshot(doc(firestore, 'users', auth.currentUser.uid), (doc) => {
+
+
+
+
+      },[])
+
+      useEffect(() => {
+                const unsub = onSnapshot(doc(firestore, 'users', auth.currentUser.uid), (doc) => {
 
           setName(doc.data()['name'])
+          return unsub
 
       })
-
-        
-        return unsub
-    
-      },[])
+      })
 
   const handleSignOut = () => {
     auth
@@ -89,7 +93,7 @@ const pickImage = async () => {
       alert("Image Uploaded")
       const docRef = firestore.collection('users').doc(auth.currentUser.uid)
       docRef.update({
-        profpic: x
+        profpic: x  //most effective way clean this up above
       });
         (error) => {
         alert(error);


### PR DESCRIPTION
because it was messing with the delete function.



I tried to work out how did you do it for the leader component and leaderboard because they use a listener to listen to changes in the username and when i delete account there was no errors.

But when i did the same for home page and settings page and included a listener it creates an error when i delete account
TypeError: undefined is not an object (evaluating 'doc.data()['name']')

        const unsub = onSnapshot(doc(firestore, 'users', auth.currentUser.uid), (doc) => {

          setName(doc.data()['name'])

      })
        return unsub
